### PR TITLE
Separate product input page and enhance charts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit>=1.36.0
 pandas>=2.1.0
 openpyxl>=3.1.0
 numpy>=1.24.0
+altair>=5.0.0


### PR DESCRIPTION
## Summary
- Split Streamlit app into input and result pages for clearer workflow
- Replace sidebar inputs with on-page forms covering all product fields
- Use Altair for cleaner chart design and add Altair to dependencies

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b10dc80d04832380d66183bd16744d