### PR TITLE
Fix streamlit_js_eval arguments

### DIFF
--- a/pages/standard_rate.py
+++ b/pages/standard_rate.py
@@ -289,7 +289,7 @@ def main() -> None:
 
     if "sr_params" not in st.session_state:
         loaded = streamlit_js_eval(
-            "window.localStorage.getItem('standard_rate_params')",
+            js_expressions="window.localStorage.getItem('standard_rate_params')",
             key="load_params",
         )
         if loaded:
@@ -413,7 +413,7 @@ def main() -> None:
         st.sidebar.warning(w)
     st.session_state.sr_params = params
     streamlit_js_eval(
-        f"window.localStorage.setItem('standard_rate_params', `{json.dumps(params, ensure_ascii=False)}`)",
+        js_expressions=f"window.localStorage.setItem('standard_rate_params', `{json.dumps(params, ensure_ascii=False)}`)",
         key="save_params",
     )
 


### PR DESCRIPTION
## Summary
- label `js_expressions` on `streamlit_js_eval` calls to prevent MarshallComponentException

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1164d0cec83239b4aba2b542e0a67