### PR TITLE
feat(rate): recompute rates from parameters and unify session state

### DIFF
--- a/pages/01_データ入力.py
+++ b/pages/01_データ入力.py
@@ -22,7 +22,7 @@ if xls is None:
     st.stop()
 
 with st.spinner("『標賃』を解析中..."):
-    params, warn1 = parse_hyochin(xls)
+    calc_params, sr_params, warn1 = parse_hyochin(xls)
 
 with st.spinner("『R6.12』製品データを解析中..."):
     df_products, warn2 = parse_products(xls, sheet_name="R6.12")
@@ -30,15 +30,13 @@ with st.spinner("『R6.12』製品データを解析中..."):
 for w in (warn1 + warn2):
     st.warning(w)
 
-st.session_state["va_params"] = params
+st.session_state["sr_params"] = sr_params
 st.session_state["df_products_raw"] = df_products
-st.session_state["be_rate"] = float(params.get("break_even_rate") or 0.0)
-st.session_state["req_rate"] = float(params.get("required_rate") or 0.0)
 
 c1, c2, c3 = st.columns(3)
-c1.metric("固定費（計）", f"{params.get('fixed_total'):,}" if params.get('fixed_total') else "-")
-c2.metric("必要利益（計）", f"{params.get('required_profit_total'):,}" if params.get('required_profit_total') else "-")
-c3.metric("年間標準稼働時間（分）", f"{params.get('annual_minutes'):,}" if params.get('annual_minutes') else "-")
+c1.metric("固定費計 (円/年)", f"{calc_params.get('fixed_total', 0):,.0f}")
+c2.metric("必要利益計 (円/年)", f"{calc_params.get('required_profit_total', 0):,.0f}")
+c3.metric("年間標準稼働分 (分/年)", f"{calc_params.get('annual_minutes', 0):,.0f}")
 
 st.divider()
 st.subheader("製品データ（先頭20件プレビュー）")

--- a/pages/02_ダッシュボード.py
+++ b/pages/02_ダッシュボード.py
@@ -8,6 +8,7 @@ import streamlit as st
 import altair as alt
 
 from utils import compute_results
+from standard_rate_core import DEFAULT_PARAMS, sanitize_params, compute_rates
 
 st.title("② ダッシュボード")
 
@@ -16,8 +17,13 @@ if "df_products_raw" not in st.session_state or st.session_state["df_products_ra
     st.stop()
 
 df_products_raw = st.session_state["df_products_raw"]
-be_rate = st.session_state.get("be_rate", 0.0)
-req_rate = st.session_state.get("req_rate", 0.0)
+base_params = st.session_state.get("sr_params", DEFAULT_PARAMS)
+base_params, warn_list = sanitize_params(base_params)
+_, base_results = compute_rates(base_params)
+be_rate = base_results["break_even_rate"]
+req_rate = base_results["required_rate"]
+for w in warn_list:
+    st.warning(w)
 
 # Controls
 with st.expander("基準賃率の調整（What-if）", expanded=False):

--- a/tests/test_rates.py
+++ b/tests/test_rates.py
@@ -80,3 +80,23 @@ def test_sanitize_params_negative():
     assert params["operation_rate"] == 0.01
     assert params["fulltime_workers"] == 1.0
     assert warnings
+
+
+def test_rates_recompute_from_params_no_excel():
+    params = DEFAULT_PARAMS.copy()
+    params["labor_cost"] += 12345.0
+    params, _ = sanitize_params(params)
+    _, res = compute_rates(params)
+    fixed_total = params["labor_cost"] + params["sga_cost"]
+    req_profit = params["loan_repayment"] + params["tax_payment"] + params["future_business"]
+    net_workers = (
+        params["fulltime_workers"]
+        + 0.75 * params["part1_workers"]
+        + params["part2_coefficient"] * params["part2_workers"]
+    )
+    minutes_per_day = params["daily_hours"] * 60
+    annual_minutes = net_workers * params["working_days"] * minutes_per_day * params["operation_rate"]
+    expected_be = fixed_total / annual_minutes
+    expected_req = (fixed_total + req_profit) / annual_minutes
+    assert math.isclose(res["break_even_rate"], expected_be, rel_tol=1e-9, abs_tol=1e-9)
+    assert math.isclose(res["required_rate"], expected_req, rel_tol=1e-9, abs_tol=1e-9)


### PR DESCRIPTION
## Summary
- extract standard rate parameters from Excel and recompute break-even/required rates centrally
- keep standard rate parameters in session state and derive metrics on demand across pages
- add regression test for parameter-based rate recalculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b158208a508323a3c9dc906e883c0f