### PR TITLE
Handle duplicate columns in compute_results

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# ensure project root is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils import compute_results
+
+
+def test_compute_results_handles_duplicate_columns():
+    df = pd.DataFrame(
+        {
+            "product_no": [1],
+            "product_name": ["A"],
+            "actual_unit_price": [100],
+            "material_unit_cost": [40],
+            "subcontract_cost": [10],
+            "daily_qty": [5],
+            "minutes_per_unit": [2],
+        }
+    )
+    # introduce duplicate column that previously caused ValueError
+    df["daily_total_minutes"] = 10
+    df = pd.concat([df, df[["daily_total_minutes"]]], axis=1)
+
+    result = compute_results(df, 10, 15)
+    assert result.loc[0, "va_per_min"] == 25.0

--- a/utils.py
+++ b/utils.py
@@ -226,6 +226,12 @@ def parse_products(xls: pd.ExcelFile, sheet_name: str = "R6.12") -> Tuple[pd.Dat
 # --------------- Core compute ---------------
 def compute_results(df_products: pd.DataFrame, break_even_rate: float, required_rate: float) -> pd.DataFrame:
     df = df_products.copy()
+    # Excel からの読み込みや二重の計算処理により、同名の列が
+    # 複数存在することがある。pandas の演算は重複した列ラベルを
+    # 含むデータフレームに対して reindex を行う際に ValueError を
+    # 投げるため、ここで重複列を除去しておく。
+    if not df.columns.is_unique:
+        df = df.loc[:, ~df.columns.duplicated(keep="last")]
     be_rate = 0.0 if break_even_rate is None else float(break_even_rate)
     req_rate = 0.0 if required_rate is None else float(required_rate)
     # recompute core metrics from raw columns


### PR DESCRIPTION
## Summary
- drop duplicated columns in compute_results to avoid pandas reindex errors
- add regression test ensuring duplicate columns no longer trigger ValueError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b176c391a483238c5735eabb0f1dd3