### PR TITLE
Improve data import and synchronize rate metrics

### DIFF
--- a/pages/02_ダッシュボード.py
+++ b/pages/02_ダッシュボード.py
@@ -30,6 +30,8 @@ scenarios[scenario_name] = base_params
 _, base_results = compute_rates(base_params)
 be_rate = base_results["break_even_rate"]
 req_rate = base_results["required_rate"]
+st.session_state["be_rate"] = be_rate
+st.session_state["req_rate"] = req_rate
 for w in warn_list:
     st.warning(w)
 
@@ -43,6 +45,11 @@ with st.expander("表示設定", expanded=False):
     topn = int(st.slider("未達SKUの上位件数（テーブル/パレート）", min_value=5, max_value=50, value=20, step=1))
 
 df = compute_results(df_products_raw, be_rate, req_rate)
+st.session_state["df_products_raw"] = df
+if "df_products_sim" in st.session_state:
+    st.session_state["df_products_sim"] = compute_results(
+        st.session_state["df_products_sim"], be_rate, req_rate
+    )
 
 # Global filters
 fcol1, fcol2, fcol3 = st.columns([1,1,2])

--- a/pages/03_標準賃率計算.py
+++ b/pages/03_標準賃率計算.py
@@ -7,6 +7,8 @@ import streamlit as st
 import numpy as np
 import pandas as pd
 
+from utils import compute_results
+
 from standard_rate_core import (
     DEFAULT_PARAMS,
     sanitize_params,
@@ -88,6 +90,16 @@ scenarios[current] = params
 st.session_state["scenarios"] = scenarios
 
 nodes, results = compute_rates(params)
+st.session_state["be_rate"] = results["break_even_rate"]
+st.session_state["req_rate"] = results["required_rate"]
+if "df_products_raw" in st.session_state:
+    st.session_state["df_products_raw"] = compute_results(
+        st.session_state["df_products_raw"], results["break_even_rate"], results["required_rate"]
+    )
+if "df_products_sim" in st.session_state:
+    st.session_state["df_products_sim"] = compute_results(
+        st.session_state["df_products_sim"], results["break_even_rate"], results["required_rate"]
+    )
 reverse_index = build_reverse_index(nodes)
 for k, ph in placeholders.items():
     affected = ", ".join(reverse_index.get(k, []))


### PR DESCRIPTION
## Summary
- fix Excel parser to capture unit rows before headers so all sample fields load
- store and propagate required/break-even rates across pages and recompute product data
- soften preview table styling for better readability

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b17c460d98832393fd0ed6e74033df